### PR TITLE
Changed result to report all missing mandatory args

### DIFF
--- a/clap/args.go
+++ b/clap/args.go
@@ -114,9 +114,12 @@ func argsToFields(args []string, fieldDescs map[string]*fieldDescription, cfg an
 				name = desc.ShortName
 			}
 			results.Mandatory = append(results.Mandatory, name)
-			return results, fmt.Errorf("mandatory argument '%s' not found: %w", name, ErrMandatoryArgument)
 		}
 	}
+	if len(results.Mandatory) != 0 {
+		return results, fmt.Errorf("mandatory argument/s: '%v' not found: %w", strings.Join(results.Mandatory, ","), ErrMandatoryArgument)
+	}
+
 	return results, nil
 }
 

--- a/clap/clap_test.go
+++ b/clap/clap_test.go
@@ -75,6 +75,31 @@ func TestMandatoryNotFound(t *testing.T) {
 	t.Logf("t: %v\n", results)
 }
 
+func TestMultipleMandatoryNotFound(t *testing.T) {
+	type config struct {
+		Image int `clap:"--image,mandatory"`
+		Num   int `clap:"--number,mandatory"`
+	}
+	wanted := []string{"image", "number"}
+
+	cfg := &config{}
+	var err error
+	var results *clap.Results
+
+	if results, err = clap.Parse([]string{"-i", "photo.png"}, cfg); err != nil {
+		if !errors.Is(err, clap.ErrMandatoryArgument) {
+			t.Errorf("parsing error: %s", err)
+			return
+		}
+		if !reflect.DeepEqual(results.Mandatory, wanted) {
+			t.Errorf("wanted: '%v', got '%v'", wanted, results.Mandatory)
+			return
+		}
+		t.Logf("t: %v\n", err)
+	}
+	t.Logf("t: %v\n", results)
+}
+
 func TestInvalidTag(t *testing.T) {
 	type config struct {
 		Test string `clap:"--test,-wrongtag"`


### PR DESCRIPTION
Under `Results` struct, Mandatory would append only the first missing argument and return:
https://github.com/fred1268/go-clap/blob/2dae1a7e96ef614293384fe90accfe0cc1ffd357/clap/args.go#L117

This pull request will make it so `Results.Mandatory` would include the full list of missing arguments
Also added a unit test for validation.